### PR TITLE
Fix: Real-time Message Deletion

### DIFF
--- a/backend/src/utils/socket.js
+++ b/backend/src/utils/socket.js
@@ -70,6 +70,10 @@ const setupSocket = (app) => {
       socket.to(roomId).emit("stopTypingIndicator");
     });
 
+    socket.on("deleteMessage", ({ roomId, messageId }) => {
+      socket.to(roomId).emit("deleteMessage", { messageId });
+    });
+
     socket.on("disconnect", () => {
       console.log(`User ${socket.id} has disconnected`);
       removeUserFromSocketMap(userId);

--- a/frontend/src/store/useAuthStore.js
+++ b/frontend/src/store/useAuthStore.js
@@ -205,6 +205,15 @@ export const useAuthStore = create((set, get) => ({
       const { setGhostTypingIndicatorLength } = useChatStore.getState();
       setGhostTypingIndicatorLength(0);
     });
+
+    socket.on("deleteMessage", ({ messageId }) => {
+      if (!messageId) return;
+      useChatStore.setState((state) => ({
+        currentChatMessages: state.currentChatMessages.filter(
+          (msg) => msg._id !== messageId
+        ),
+      }));
+    });
   },
 
   disconnectSocket: () => {

--- a/frontend/src/store/useChatStore.js
+++ b/frontend/src/store/useChatStore.js
@@ -156,6 +156,11 @@ export const useChatStore = create((set, get) => ({
           (msg) => msg._id !== messageId
         ),
       }));
+      const { socket } = useAuthStore.getState();
+      const roomId = `chat-${get().selectedChatId}`;
+      if (socket) {
+        socket.emit("deleteMessage", { roomId, messageId });
+      }
     } catch (error) {
       console.error("Error deleting message:", error);
     } finally {


### PR DESCRIPTION
### Problem
When a user deleted a message, it disappeared instantly on their side but recipients didn't see the deletion unless they refreshed the page, breaking the real-time experience.

### Solution
- **Backend**: Added `deleteMessage` socket event handler that broadcasts deletion to all room participants
- **Frontend**: Added socket listener to handle incoming `deleteMessage` events and update UI instantly

### Changes Made
- `backend/src/utils/socket.js`: Added `deleteMessage` event handler
- `frontend/src/store/useAuthStore.js`: Added socket listener for `deleteMessage`
- `frontend/src/store/useChatStore.js`: Updated `deleteMessage` function to emit socket event

### Testing
- ✅ Message deletion now syncs in real-time across all clients
- ✅ Both sender and recipient see deletion instantly
- ✅ No page refresh required

### Before/After
**Before**: Delete message → Only sender sees deletion → Recipients need refresh
**After**: Delete message → All participants see deletion instantly

Fixes #13 