### PR TITLE
Fix: Chat Sidebar Shows Stale Message After Deletion

### DIFF
--- a/frontend/src/store/useAuthStore.js
+++ b/frontend/src/store/useAuthStore.js
@@ -208,11 +208,14 @@ export const useAuthStore = create((set, get) => ({
 
     socket.on("deleteMessage", ({ messageId }) => {
       if (!messageId) return;
+
       useChatStore.setState((state) => ({
         currentChatMessages: state.currentChatMessages.filter(
           (msg) => msg._id !== messageId
         ),
       }));
+
+      useChatStore.getState().getAllChats();
     });
   },
 

--- a/frontend/src/store/useChatStore.js
+++ b/frontend/src/store/useChatStore.js
@@ -140,17 +140,9 @@ export const useChatStore = create((set, get) => ({
 
   deleteMessage: async (messageId) => {
     set({ isDeletingMessage: true });
-    const { currentChatMessages } = get();
-    const messageToDelete = currentChatMessages.find(
-      (msg) => msg._id === messageId
-    );
-    if (!messageToDelete) {
-      console.error("Message not found:", messageId);
-      set({ isDeletingMessage: false });
-      return;
-    }
     try {
       await api.delete(`/messages/${messageId}`);
+      get().getAllChats();
       set((state) => ({
         currentChatMessages: state.currentChatMessages.filter(
           (msg) => msg._id !== messageId


### PR DESCRIPTION
### Problem
When a user deleted a message, the chat sidebar continued displaying the deleted message as the most recent preview, creating a misleading UI state where users saw content that no longer existed in the conversation.

### Solution
Implemented a complete backend + frontend solution to properly handle latest message updates:

**Backend Changes:**
- Enhanced `deleteMessage` controller to recalculate `latestMessage` after deletion
- Added logic to find the most recent remaining message using `reduce()` with date comparison
- Properly handle empty chat case by setting `latestMessage` to `null`
- Update chat document in database with new latest message

**Frontend Changes:**
- Added `getAllChats()` call after successful deletion to refresh sidebar
- Enhanced socket handler to trigger chat list refresh for real-time updates
- Maintained real-time message removal from current chat view

### Testing
- ✅ Delete most recent message → Sidebar shows previous message
- ✅ Delete older message → Sidebar unchanged (correct behavior)
- ✅ Delete all messages → Sidebar shows "No messages yet"
- ✅ Real-time deletion syncs for all chat participants
- ✅ Database consistency maintained with proper latest message tracking

### Before/After
**Before:** Delete latest message → Sidebar shows deleted content until refresh
**After:** Delete latest message → Sidebar immediately shows correct latest message or empty state

Resolves chat sidebar inconsistency with proper backend recalculation and frontend refresh strategy.

Fixes #10 